### PR TITLE
Add vertical divider bar between Business and Enterprise blocks

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -53,6 +53,7 @@ a {
 
 #business-features {
     position: relative;
+    border-right: 2px solid #ccc; /* Add a right border to create a vertical divider */
 }
 
 /* Centering the content of #feature-detail-container */


### PR DESCRIPTION
Fixes #5

Adds a vertical divider between the Business and Enterprise blocks to enhance visual separation.

- **CSS Update**: Adds a 2px solid border to the right side of the `#business-features` section, effectively creating a vertical divider between the Business and Enterprise blocks as intended in the issue description.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rajbos/copilot-videos/issues/5?shareId=0a96e2bd-91da-4b6b-8e3d-3a8eda50f464).