### PR TITLE
Equalize spacing around vertical divider

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2,7 +2,7 @@
 #main-container {
     display: flex;
     justify-content: space-between;
-    padding: 20px;
+    padding: 20px 10px; /* Adjusted padding to ensure equal spacing around the divider */
     align-items: flex-start;
     flex-direction: row;
 }


### PR DESCRIPTION
Closes #8

Adjusts padding in `#main-container` to ensure equal spacing around the divider in `styles.css`.

- Modifies the padding of `#main-container` from `20px` to `20px 10px` to achieve equal spacing around the vertical divider between the enterprise box and the business box.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rajbos/copilot-videos/issues/8?shareId=9855716a-8ccb-4c52-8bfd-5a6546ba4930).