### PR TITLE
Add unselect option to RSS filter buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -52,18 +52,27 @@ document.addEventListener('DOMContentLoaded', function() {
             // Function to filter news items based on the selected feed
             function filterNews(feedName, clickedButton) {
                 const newsItems = document.querySelectorAll('.news-item');
-                newsItems.forEach(item => {
-                    if (item.querySelector('span').textContent === feedName) {
+                const isActive = clickedButton.classList.contains('active');
+                // Toggle active class on clicked button
+                clickedButton.classList.toggle('active');
+                if (isActive) {
+                    // If the button was already active, display all news items
+                    newsItems.forEach(item => {
                         item.style.display = '';
-                    } else {
-                        item.style.display = 'none';
-                    }
-                });
-                // Toggle active class on clicked button and remove from others
+                    });
+                } else {
+                    // Filter news items based on the selected feed
+                    newsItems.forEach(item => {
+                        if (item.querySelector('span').textContent === feedName) {
+                            item.style.display = '';
+                        } else {
+                            item.style.display = 'none';
+                        }
+                    });
+                }
+                // Ensure only the clicked button can be active at a time
                 document.querySelectorAll('.filter-btn').forEach(button => {
-                    if (button === clickedButton) {
-                        button.classList.add('active');
-                    } else {
+                    if (button !== clickedButton) {
                         button.classList.remove('active');
                     }
                 });


### PR DESCRIPTION
Closes #22

Implements the 'unselect' functionality for RSS filter buttons in `script.js`, allowing users to display all RSS items again by clicking an active filter button.
- **Toggle 'active' state:** Modifies the `filterNews` function to check if a clicked filter button already has the 'active' class. If so, it toggles the 'active' class off, effectively unselecting the filter and displaying all news items.
- **Display logic adjustment:** Ensures that when a filter is unselected by clicking an active button, all news items are displayed again, reverting the filter action.
- **Single active filter:** Updates the logic to ensure only one filter button can be active at a time, removing the 'active' class from all other buttons when a new filter is selected or an active filter is unselected.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rajbos/copilot-videos/issues/22?shareId=cd2410e7-40b2-4f05-9ce8-73659f67c734).