### PR TITLE
Add 'all' category button to RSS filter

### DIFF
--- a/script.js
+++ b/script.js
@@ -49,6 +49,25 @@ document.addEventListener('DOMContentLoaded', function() {
                 filterButtonsContainer.appendChild(button);
             });
 
+            // Add an 'all' category button
+            const allButton = document.createElement('button');
+            allButton.textContent = 'All';
+            allButton.className = 'filter-btn';
+            allButton.addEventListener('click', function() {
+                unselectFiltersAndShowAll();
+            });
+            filterButtonsContainer.prepend(allButton);
+
+            // Function to unselect any active filter and show all RSS items
+            function unselectFiltersAndShowAll() {
+                document.querySelectorAll('.news-item').forEach(item => {
+                    item.style.display = '';
+                });
+                document.querySelectorAll('.filter-btn').forEach(button => {
+                    button.classList.remove('active');
+                });
+            }
+
             // Function to filter news items based on the selected feed
             function filterNews(feedName, clickedButton) {
                 const newsItems = document.querySelectorAll('.news-item');
@@ -80,6 +99,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
             // Fetch and display RSS feeds
             const rssFeeds = data.rssFeeds.feeds;
+            let totalItemCount = 0; // Initialize total item count
             rssFeeds.forEach(feed => {
                 fetch(feed.url)
                     .then(response => response.text())
@@ -89,6 +109,7 @@ document.addEventListener('DOMContentLoaded', function() {
                         let itemCount = 0; // Count the number of items for the current feed
                         items.forEach(item => {
                             itemCount++;
+                            totalItemCount++; // Increment total item count
                             const title = item.querySelector("title").textContent;
                             const description = item.querySelector("description").textContent;
                             const pubDate = new Date(item.querySelector("pubDate").textContent);
@@ -105,6 +126,8 @@ document.addEventListener('DOMContentLoaded', function() {
                                 button.textContent = `${feed.name} (${itemCount})`;
                             }
                         });
+                        // Update the 'all' button text to include the total count of all RSS items
+                        allButton.textContent = `All (${totalItemCount})`;
                     });
             });
         })


### PR DESCRIPTION
Closes #24

Implements the addition of an 'all' category button to the RSS filter buttons, enabling users to unselect any active filter and display all RSS items, along with showing the total count of loaded RSS items.

- **Adds an 'all' category button** at the beginning of the filter buttons container. This button, when clicked, removes the active state from any filter and displays all RSS items.
- **Implements a function** `unselectFiltersAndShowAll` to handle the display logic when the 'all' button is clicked, ensuring all news items are shown and no filter button is marked as active.
- **Updates the total count display logic** to include the count of all RSS items on the 'all' category button. This is achieved by initializing a total item count variable, incrementing it as RSS items are loaded, and updating the 'all' button's text to reflect the total count.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rajbos/copilot-videos/issues/24?shareId=fe2a1386-dd1a-46c6-a4cd-052153ea77ef).