### PR TITLE
Add crawling of specified blog URL to news section

### DIFF
--- a/data.json
+++ b/data.json
@@ -114,5 +114,10 @@
         "url": "https://github.blog/changelog/label/copilot/feed/"
       }
     ]
+  },
+  "blogFeeds": {
+    "urls": [
+      "https://github.blog/?s=Copilot"
+    ]
   }
 }

--- a/script.js
+++ b/script.js
@@ -130,6 +130,33 @@ document.addEventListener('DOMContentLoaded', function() {
                         allButton.textContent = `All (${totalItemCount})`;
                     });
             });
+
+            // Function to crawl and display blog posts
+            function crawlAndDisplayBlogPosts() {
+                const blogFeeds = data.blogFeeds.urls;
+                blogFeeds.forEach(url => {
+                    fetch(url)
+                        .then(response => response.text())
+                        .then(html => {
+                            const parser = new DOMParser();
+                            const doc = parser.parseFromString(html, 'text/html');
+                            const posts = doc.querySelectorAll('.post-item');
+                            posts.forEach(post => {
+                                const title = post.querySelector('.post-title').textContent;
+                                const description = post.querySelector('.post-excerpt').textContent;
+                                const date = post.querySelector('.post-date').textContent;
+                                const blogItem = document.createElement('div');
+                                blogItem.className = 'news-item blog-post';
+                                blogItem.innerHTML = `<h4>${title}</h4><p>${description}</p><span class="date">Published: ${date}</span>`;
+                                newsContainer.appendChild(blogItem);
+                            });
+                        })
+                        .catch(error => console.error('Error loading blog posts:', error));
+                });
+            }
+
+            // Call the function to crawl and display blog posts
+            crawlAndDisplayBlogPosts();
         })
         .catch(error => console.error('Error loading the data:', error));
 });


### PR DESCRIPTION
Related to #26. Needs testing

Adds functionality to crawl a specified blog URL and display its posts in the news section, alongside existing RSS feed items. This enhancement addresses the need for a more diverse content source in the news section as outlined in the issue.

- **Data Structure Update**: Adds a "blogFeeds" section to `data.json` to include the specified blog URL for crawling.
- **Script Enhancement**: Implements a new function `crawlAndDisplayBlogPosts` in `script.js` that:
  - Fetches the HTML content from the specified blog URL.
  - Parses the HTML to extract post details such as title, description, and publication date.
  - Dynamically creates and appends each post as a distinct element within the news section, applying a unique styling class `blog-post` for differentiation.
- **Event Handling**: Modifies the `DOMContentLoaded` event listener to invoke the `crawlAndDisplayBlogPosts` function, ensuring blog posts are displayed upon page load alongside RSS feed items.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rajbos/copilot-videos/issues/26?shareId=e6436646-63d8-42ff-b852-4fa38040dd59).