### PR TITLE
Filter GitHub Blog RSS Feed

### DIFF
--- a/data.json
+++ b/data.json
@@ -112,6 +112,10 @@
       {
         "name": "Copilot",
         "url": "https://github.blog/changelog/label/copilot/feed/"
+      },
+      {
+        "name": "Copilot Blog",
+        "url": "https://github.blog/feed/?tag=github-copilot%2Cgithub-copilot-extensions%2Cgithub-copilot-chat"
       }
     ]
   }


### PR DESCRIPTION
Closes #26

Updates the `data.json` file to include a new RSS feed for GitHub Blog, specifically filtered for content related to GitHub Copilot and its extensions.

- Adds a new RSS feed entry named "Copilot Blog" to the `rssFeeds` section of `data.json`.
- The new feed URL filters for posts tagged with "GitHub Copilot", "GitHub Copilot Extensions", and "GitHub Copilot Chat", aiming to provide more relevant content in the RSS overview.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rajbos/copilot-videos/issues/26?shareId=af79023a-1606-43c7-8dbb-e5c1fc6e046c).